### PR TITLE
feat: add Send MMS service with file picker support

### DIFF
--- a/custom_components/textnow/__init__.py
+++ b/custom_components/textnow/__init__.py
@@ -52,13 +52,20 @@ async def async_setup_services(hass: HomeAssistant, coordinator: TextNowDataUpda
     """Set up services for TextNow."""
     from .services import (
         async_send_message,
+        async_send_mms,
         SERVICE_SEND_SCHEMA,
+        SERVICE_SEND_MMS_SCHEMA,
     )
 
     async def send_message_service(call):
         """Handle send message service call."""
         await async_send_message(hass, coordinator, call.data)
 
+    async def send_mms_service(call):
+        """Handle send MMS service call."""
+        await async_send_mms(hass, coordinator, call.data)
+
     # Register service with schema for validation
     hass.services.async_register(DOMAIN, "send", send_message_service, schema=SERVICE_SEND_SCHEMA)
+    hass.services.async_register(DOMAIN, "send_mms", send_mms_service, schema=SERVICE_SEND_MMS_SCHEMA)
 

--- a/custom_components/textnow/services.yaml
+++ b/custom_components/textnow/services.yaml
@@ -20,3 +20,33 @@ send:
       selector:
         text:
           multiline: true
+
+send_mms:
+  name: Send MMS
+  description: Send an MMS message with media attachment to a contact.
+  fields:
+    contact_id:
+      name: Contact
+      description: Select a contact to send message to.
+      required: true
+      example: "sensor.textnow_contact_1"
+      selector:
+        entity:
+          domain: sensor
+          filter:
+            - integration: textnow
+    file_path:
+      name: File
+      description: Path to media file (e.g., /local/image.jpg or full path). Use /local/ prefix for files in www folder.
+      required: true
+      example: "/local/image.jpg"
+      selector:
+        text:
+    message:
+      name: Message
+      description: Optional message text to send with the media.
+      required: false
+      example: "Check out this image"
+      selector:
+        text:
+          multiline: true


### PR DESCRIPTION
- Add new textnow.send_mms service for sending MMS messages
- Implement 3-step MMS flow per API docs: get upload URL, upload file, send attachment
- Add interactive UI with contact selector and file path field
- Support /local/ paths for Home Assistant www folder
- Update coordinator.send_mms to follow TextNow API endpoints
- Register service in __init__.py and add service definition in services.yaml