### PR TITLE
fix: Update CSRF token handling and config flow to use cookie string

### DIFF
--- a/custom_components/textnow/translations/en.json
+++ b/custom_components/textnow/translations/en.json
@@ -6,8 +6,7 @@
         "description": "Enter your TextNow account credentials to connect",
         "data": {
           "username": "Username",
-          "connect_sid": "connect.sid Cookie",
-          "csrf": "_csrf Cookie"
+          "cookie_string": "Full Cookie String"
         }
       },
       "account": {
@@ -45,8 +44,10 @@
     },
     "error": {
       "username_required": "Username is required",
-      "connect_sid_required": "connect.sid cookie is required",
-      "csrf_required": "_csrf cookie is required",
+      "cookie_string_required": "Cookie string is required",
+      "connect_sid_missing": "connect.sid cookie not found in cookie string",
+      "csrf_missing": "_csrf cookie not found in cookie string",
+      "xsrf_token_missing": "XSRF-TOKEN cookie not found in cookie string",
       "invalid_phone": "Phone number must be exactly 10 digits",
       "invalid_credentials": "Invalid credentials",
       "cannot_connect": "Cannot connect to TextNow",


### PR DESCRIPTION
## Summary
Fixed CSRF token authentication issues and improved config flow to match working server implementation.

## What Changed
- Fixed CSRF token resolution to use XSRF-TOKEN cookie value first (matching API documentation)
- Updated config flow to accept full cookie string instead of individual cookies
- Added cookie parsing logic matching working server implementation
- Updated headers to match API requirements (Referer, Origin, Accept-Language)
- Improved error handling for missing required cookies

## Testing/Verification
- Config flow now accepts full cookie string and parses required cookies automatically
- CSRF token handling matches deterministic logic from API documentation
- Headers match working server implementation

## Risks/Rollback
Low risk - improves authentication reliability. If issues occur, can revert to previous version.